### PR TITLE
Add api for new player registration

### DIFF
--- a/src/server/main/com/cs414/blueberries/GameApi.java
+++ b/src/server/main/com/cs414/blueberries/GameApi.java
@@ -1,6 +1,8 @@
 package com.cs414.blueberries;
 
 import static spark.Spark.*;
+
+import com.google.gson.Gson;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -15,7 +17,7 @@ import spark.Filter;
 
 public class GameApi {
     public static void main(String[] args) {
-        GlobalData.readPlayers("./JSONfiles/Players.json");
+        GlobalData.readPlayers(GlobalData.PLAYERS_FILENAME);
         System.out.println(GlobalData.players);
         after((Filter) (request, response) -> {
             response.header("Access-Control-Allow-Origin", "*");
@@ -23,6 +25,12 @@ public class GameApi {
         });
 
         get("/hello", (req, res) -> "Hello World");
+        post("/register", (req, res) -> {
+            Gson gson = new Gson();
+            Player player = gson.fromJson(req.body(), Player.class);
+            System.out.println("Registering new player: " + player.toString());
+            return player.register();
+        });
     }
 
 

--- a/src/server/main/com/cs414/blueberries/GlobalData.java
+++ b/src/server/main/com/cs414/blueberries/GlobalData.java
@@ -6,15 +6,16 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
+import java.io.*;
 import java.util.HashMap;
 import java.util.ArrayList;
 
 
 public class GlobalData {
+
+    public static String PLAYERS_FILENAME = "./JSONfiles/Players.json";
+    public static String GAMES_FILENAME = "./JSONfiles/Games.json";
+
     public static HashMap<String, Player> players = new HashMap<>();
     public static ArrayList<Integer> games = new ArrayList<>();
 
@@ -24,10 +25,19 @@ public class GlobalData {
             Player [] playersArray = gson.fromJson(new FileReader(filename), Player[].class);
             for (Player player : playersArray)
                 players.put(player.getUserId(), player);
-
-        } catch (FileNotFoundException ignored) {
-
+        } catch (FileNotFoundException notIgnored) {
+            notIgnored.printStackTrace();
         }
+    }
 
+    public static void writePlayers(String filename){
+        Gson gson = new Gson();
+        try {
+            Writer fileWriter = new FileWriter(filename);
+            gson.toJson(GlobalData.players.values(), fileWriter);
+            fileWriter.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/server/main/com/cs414/blueberries/Player.java
+++ b/src/server/main/com/cs414/blueberries/Player.java
@@ -1,6 +1,8 @@
 package com.cs414.blueberries;
 
 import java.util.ArrayList;
+import java.util.Map;
+
 public class Player {
     private String email;
     private String userId;
@@ -13,10 +15,24 @@ public class Player {
         this.userId = userId;
         this.password = password;
         this.gameIDs = gameIDs;
+        this.register();
+    }
+
+    public Player(String email, String userId, String password) {
+        this.email = email;
+        this.userId = userId;
+        this.password = password;
+        this.gameIDs = new ArrayList<Integer>();
+        this.register();
     }
 
 
-
+    public boolean register() {
+        if (GlobalData.players.containsKey(this.userId)) return false;
+        GlobalData.players.put(this.userId, this);
+        GlobalData.writePlayers(GlobalData.PLAYERS_FILENAME);
+        return true;
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
These changes don't have unit testing attached to them because they technically would be "integration tested" (i.e. you would need to register the new player and check that the database size has changed/check that the query operation succeeds)

Here's an example I used with Postman (POST localhost:4567/register):
{
		"email": "myEmail@email.com",
		"userId": "id",
		"password": "1234"
}
and it successfully updated the player list.

closes #8 